### PR TITLE
Insert info embed before the suggestion modal

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,10 +1,15 @@
+// IMPORTANT: Only add the partnerships_channel once that channel actually contains a server with a venting channel.
+// That field is just used to provide the details for the "we will not add a venting channel" notice to the
+// suggestion workflow, so it should not direct users to the channel if none of the servers there have a venting channel.
+
 module.exports = {
     "959551566388547676": { // TransPlace
         "suggestion_channel": "977280417877090424",
-        "suggestion_ban_role": "994776459086401576"
+        "suggestion_ban_role": "994776459086401576",
+        "partnerships_channel": "987881457852776528"
     },
     "1087014898199969873": { // EnbyPlace
         "suggestion_channel": "1258486010996592701",
         "suggestion_ban_role": "1258486058425913345"
-    },
+    }
 }

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -29,5 +29,11 @@ module.exports = async (client, interaction) => {
 
         if (!selectMenu) return;
         else selectMenu.run(client, interaction, selected);
+    } else if (interaction.isButton()) {
+        const buttonId = interaction.customId;
+        const button = client.components.get(buttonId);
+
+        if (!button) return;
+        else button.run(client, interaction, null);
     }
 };

--- a/handlers/component/launchSuggestionModal.js
+++ b/handlers/component/launchSuggestionModal.js
@@ -1,0 +1,52 @@
+const { ModalBuilder, ActionRowBuilder, TextInputBuilder } = require("discord.js");
+
+exports.run = async (client, interaction, options) => {
+    const modal = new ModalBuilder()
+        .setCustomId("suggestModalSubmit")
+        .setTitle(`Create a Suggestion!`)
+        .addComponents([
+            new ActionRowBuilder().addComponents([
+                new TextInputBuilder()
+                    .setCustomId("suggestion")
+                    .setRequired(true)
+                    .setMinLength(5)
+                    .setMaxLength(195)
+                    .setLabel('Suggestion')
+                    .setStyle(1)
+                    .setPlaceholder('Do X.'),
+            ]),
+            new ActionRowBuilder().addComponents([
+                new TextInputBuilder()
+                    .setCustomId("reason")
+                    .setRequired(true)
+                    .setMinLength(5)
+                    .setMaxLength(1024)
+                    .setLabel('Reason')
+                    .setStyle(2)
+                    .setPlaceholder('Because Y.'),
+            ]),
+            new ActionRowBuilder().addComponents([
+                new TextInputBuilder()
+                    .setCustomId("info")
+                    .setRequired(false)
+                    .setMinLength(5)
+                    .setMaxLength(1024)
+                    .setLabel('Additional Info')
+                    .setStyle(2)
+                    .setPlaceholder('Optional.'),
+            ]),
+            new ActionRowBuilder().addComponents([
+                new TextInputBuilder()
+                    .setCustomId("asset")
+                    .setRequired(false)
+                    .setMinLength(5)
+                    .setMaxLength(1024)
+                    .setLabel('Image/Gif Asset ')
+                    .setStyle(2)
+                    .setPlaceholder('Optional imgur image url (https://i.imgur.com/example.png)'),
+            ])
+        ],);
+
+
+    await interaction.showModal(modal);
+}

--- a/handlers/component/suggestModalSubmit.js
+++ b/handlers/component/suggestModalSubmit.js
@@ -6,6 +6,7 @@ const {
 } = require('discord.js');
 
 exports.run = async (client, interaction, options) => {
+    await interaction.deferUpdate();
 
     function escapeMarkdown(text) {
         var unescaped = text.replace(/\\(\*|_|`|~|\\)/g, '$1'); // unescape any "backslashed" character
@@ -39,7 +40,7 @@ exports.run = async (client, interaction, options) => {
         else {
             replyEmbed.setTitle("Attachment URL Invalid:\n***Must Be a valid imgur URL***");
             // replyEmbed.setDescription(`Make sure the image is one of the following: png/jpg/jpeg/apng/gif.\nCheck that the url is formatted like: (https://i.imgur.com/image.png)\n\nIf you have a URL like (https://imgur.com/a/image):\nRight click the image on imgur and click \"Open image in New Tab\" and copy the url it opens it\n\n(It then should look like the https://i.imgur.com/\n\n\`\`\`Suggestion:\n${title}\`\`\`\`\`\`Reason:\n${reason}\`\`\`${extra}${extraImage})`)
-            return interaction.reply({
+            return interaction.editReply({
                 content: "Failed to send suggestion. (Attached is attempted values.)",
                 embeds: [replyEmbed],
                 ephemeral: true,
@@ -52,7 +53,7 @@ exports.run = async (client, interaction, options) => {
     const suggestionChannel = interaction.guild.channels.cache.get(client.config[interaction.guild.id].suggestion_channel);
 
     if (!suggestionChannel) {
-        return interaction.reply({
+        return interaction.editReply({
             content: "Unable to find suggestions channel, this should not occur, please notify server staff of this issue.",
             ephemeral: true,
         });
@@ -116,7 +117,7 @@ exports.run = async (client, interaction, options) => {
             .setStyle(ButtonStyle.Link))
     ]);
 
-    return interaction.reply({
+    return interaction.editReply({
         embeds: [replyEmbed],
         components: [replyEmbedRow],
         ephemeral: true,

--- a/handlers/slash/suggest.js
+++ b/handlers/slash/suggest.js
@@ -1,8 +1,8 @@
 const {
-    ModalBuilder,
     ActionRowBuilder,
-    TextInputBuilder,
     SlashCommandBuilder,
+    EmbedBuilder,
+    ButtonBuilder,
 } = require('discord.js');
 
 
@@ -11,60 +11,50 @@ exports.data = new SlashCommandBuilder()
     .setDescription("Make a server suggestion");
 
 exports.run = async (client, interaction, options) => {
+    const config = client.config[interaction.guild.id];
 
-    if (interaction.member.roles.cache.has(client.config[interaction.guild.id].suggestion_ban_role)) {
+    if (interaction.member.roles.cache.has(config.suggestion_ban_role)) {
         return interaction.reply({
             content: "You have been banned from making suggestions. Please open a staff ticket if you believe this is a mistake.",
             ephemeral: true,
         });
     }
 
-    const modal = new ModalBuilder()
-        .setCustomId("suggestModalSubmit")
-        .setTitle(`Create a Suggestion!`)
-        .addComponents([
-            new ActionRowBuilder().addComponents([
-                new TextInputBuilder()
-                    .setCustomId("suggestion")
-                    .setRequired(true)
-                    .setMinLength(5)
-                    .setMaxLength(195)
-                    .setLabel('Suggestion')
-                    .setStyle(1)
-                    .setPlaceholder('Do X.'),
-            ]),
-            new ActionRowBuilder().addComponents([
-                new TextInputBuilder()
-                    .setCustomId("reason")
-                    .setRequired(true)
-                    .setMinLength(5)
-                    .setMaxLength(1024)
-                    .setLabel('Reason')
-                    .setStyle(2)
-                    .setPlaceholder('Because Y.'),
-            ]),
-            new ActionRowBuilder().addComponents([
-                new TextInputBuilder()
-                    .setCustomId("info")
-                    .setRequired(false)
-                    .setMinLength(5)
-                    .setMaxLength(1024)
-                    .setLabel('Additional Info')
-                    .setStyle(2)
-                    .setPlaceholder('Optional.'),
-            ]),
-            new ActionRowBuilder().addComponents([
-                new TextInputBuilder()
-                    .setCustomId("asset")
-                    .setRequired(false)
-                    .setMinLength(5)
-                    .setMaxLength(1024)
-                    .setLabel('Image/Gif Asset ')
-                    .setStyle(2)
-                    .setPlaceholder('Optional imgur image url (https://i.imgur.com/example.png)'),
+    await interaction.reply({
+        ephemeral: true,
+        embeds: [
+            new EmbedBuilder()
+                .setTitle("Please read before suggesting!")
+                .setDescription("Thank you for suggesting improvements to the server! Before you proceed, please read the following commonly rejected suggestions and make sure your suggestion does not fall under any of these.")
+                .addFields({
+                    name: "Politics Channels",
+                    value: "We do not allow politics to be discussed in this server. There was previously a politics channel, but due to persistent issues, it was removed, and we will not bring it back."
+                })
+                .addFields({
+                    name: "Venting Channels",
+                    value: `This is not the server for venting, as it can be upsetting to other users. Additionally, staff are not trained to provide the help and support needed for those in distress. As such, we will not add any sort of venting or ranting channel${config.partnerships_channel ? `, but if you want one, please check <#${config.partnerships_channel}> for a list of our partners, some of which have venting channels` : ""}.`
+                })
+                .addFields({
+                    name: "Age Roles",
+                    value: "Roles for identifying users as minors/adults or tagging users by age have been proposed before, and due to the risks and dangers outweighing any potential benefits of having them, we will not consider those roles."
+                })
+                .addFields({
+                    name: "Unbanning discussion on DIY HRT/medical treatment",
+                    value: "DIY medical treatment is dangerous. We maintain the ban on all discussions about or advocacy of illegitimate/DIY treatment, including but not limited to HRT, binders, dosages, etc. due to the potential harm to users and will not consider changing this policy."
+                })
+                .addFields({
+                    name: "Not related to any of these?",
+                    value: "If you have a suggestion for a feature, improvement, or change that is not related to the above, click below to continue. Thank you!"
+                })
+        ],
+        components: [
+            new ActionRowBuilder()
+                .addComponents([
+                    new ButtonBuilder()
+                        .setCustomId("launchSuggestionModal")
+                        .setLabel("Continue")
+                        .setStyle(1)
             ])
-        ],);
-
-
-    await interaction.showModal(modal);
+        ]
+    })
 };


### PR DESCRIPTION
- users frequently suggest some of the things that are not going to be considered (politics, venting, age roles, unbanning DIY HRT discussions)
- this PR adds an info embed when the user uses `/suggest` prompting them to read info about that first, and a "continue" button now opens the modal
- the remaining logic remains the same